### PR TITLE
Print Python/Sphinx/docutils versions in doc build

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -145,6 +145,20 @@ jobs:
         run: |
           pip install -r requirements.txt
 
+      - name: Print build environment
+        # Records the exact Python/pip/Sphinx/docutils versions used in
+        # this run, so "works locally, fails in CI" reports are diffable
+        # without a round-trip to reproduce the env.
+        run: |
+          echo "::group::Python"
+          python --version
+          pip --version
+          echo "::endgroup::"
+          echo "::group::Doc build packages"
+          pip show sphinx docutils sphinx-gallery numpydoc pydata-sphinx-theme 2>/dev/null \
+            | grep -E "^(Name|Version|Location):" || true
+          echo "::endgroup::"
+
       - name: Cache doc build
         if: ${{ inputs.CACHE_GALLERY_EXAMPLES }}
         uses: actions/cache@v5


### PR DESCRIPTION
### Summary

Adds a "Print build environment" step to the reusable `doc.yml` workflow, right after the package install. The step logs:

- `python --version`, `pip --version`
- `pip show` for `sphinx`, `docutils`, `sphinx-gallery`, `numpydoc`, `pydata-sphinx-theme`

All output is wrapped in collapsed `::group::` blocks so it doesn't pollute the visible log.

### Motivation

"Works locally, fails in CI" reports for the HyperSpy doc build have repeatedly been caused by docutils/sphinx version drift between local and CI. The local `scripts/check-docs.py` produces no warnings, the CI `make html` produces 5+ reST errors — and the only way to diagnose is to either reproduce the CI env locally or bisect docutils versions. Both are slow.

Recording the exact versions in the CI log makes the diagnosis a single diff: a `pip show` output comparison between local and CI is enough to identify the drift. Saves an env-reproduction round-trip per bug.

### Change

```yaml
- name: Install library
  if: ${{ inputs.install_dependencies_only != true }}
  run: |
    pip install .'[${{ inputs.pip_extra_doc }}]' colorama

+ - name: Print build environment
+   # Records the exact Python/pip/Sphinx/docutils versions used in
+   # this run, so "works locally, fails in CI" reports are diffable
+   # without a round-trip to reproduce the env.
+   run: |
+     echo "::group::Python"
+     python --version
+     pip --version
+     echo "::endgroup::"
+     echo "::group::Doc build packages"
+     pip show sphinx docutils sphinx-gallery numpydoc pydata-sphinx-theme 2>/dev/null \
+       | grep -E "^(Name|Version|Location):" || true
+     echo "::endgroup::"
```

### Notes

- Applies to all `hyperspy/*` repos that call this reusable workflow (no consumer changes needed).
- No new permissions required; `pip show` is read-only and runs in the existing build step context.
- Output is visible to anyone with read access to the build log; if any of these versions are considered sensitive, the step could be gated on `github.event_name == 'pull_request'` instead.

Assisted-by: opencode:minimax-m3